### PR TITLE
requirements.txt: add missing onnx and bump onnxruntime to 1.14.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 #tensorflow==2.8
 #tf2onnx
-onnxruntime==1.13.1
+onnxruntime==1.14.1
+onnx==1.13.1
 bin2c


### PR DESCRIPTION
Thanks for figuring out how to statically compile onnxruntime! :)

When I tried your project, I had to add onnx as a requirement or else I had an error. I also figured I'd bump the onnxruntime requirement to the latest. Hope you or someone will find it useful, cheers!