### PR TITLE
Refactoring build scripts for macOS and windows

### DIFF
--- a/build-mac.sh
+++ b/build-mac.sh
@@ -1,80 +1,58 @@
 #!/usr/bin/env bash
-set -e
-python onnxruntime/tools/ci_build/build.py \
---build_dir onnxruntime/build/macOS_x86_64 \
---config=MinSizeRel \
---parallel \
---minimal_build \
---apple_deploy_target="10.13" \
---disable_ml_ops --disable_exceptions --disable_rtti \
---include_ops_by_config model.required_operators_and_types.config \
---enable_reduced_operator_type_support \
---cmake_extra_defines CMAKE_OSX_ARCHITECTURES=x86_64 \
---skip_tests
+set -euf -o pipefail
 
-python onnxruntime/tools/ci_build/build.py \
---build_dir onnxruntime/build/macOS_arm64 \
---config=MinSizeRel \
---parallel \
---minimal_build \
---apple_deploy_target="10.14" \
---disable_ml_ops --disable_exceptions --disable_rtti \
---include_ops_by_config model.required_operators_and_types.config \
---enable_reduced_operator_type_support \
---cmake_extra_defines CMAKE_OSX_ARCHITECTURES=arm64 \
---skip_tests
+onnx_config="${1:-model.required_operators_and_types.config}"
 
-libtool -static -o onnxruntime-macOS_x86_64-static-combined.a \
-./onnxruntime/build/macOS_x86_64/MinSizeRel/libonnx.a \
-./onnxruntime/build/macOS_x86_64/MinSizeRel/libonnxruntime_graph.a \
-./onnxruntime/build/macOS_x86_64/MinSizeRel/libonnx_proto.a \
-./onnxruntime/build/macOS_x86_64/MinSizeRel/libonnxruntime_mlas.a \
-./onnxruntime/build/macOS_x86_64/MinSizeRel/libonnx_test_data_proto.a \
-./onnxruntime/build/macOS_x86_64/MinSizeRel/libonnxruntime_optimizer.a \
-./onnxruntime/build/macOS_x86_64/MinSizeRel/libonnx_test_runner_common.a \
-./onnxruntime/build/macOS_x86_64/MinSizeRel/libonnxruntime_providers.a \
-./onnxruntime/build/macOS_x86_64/MinSizeRel/libonnxruntime_common.a \
-./onnxruntime/build/macOS_x86_64/MinSizeRel/libonnxruntime_session.a \
-./onnxruntime/build/macOS_x86_64/MinSizeRel/libonnxruntime_flatbuffers.a \
-./onnxruntime/build/macOS_x86_64/MinSizeRel/libonnxruntime_test_utils.a \
-./onnxruntime/build/macOS_x86_64/MinSizeRel/libonnxruntime_framework.a \
-./onnxruntime/build/macOS_x86_64/MinSizeRel/libonnxruntime_util.a \
-./onnxruntime/build/macOS_x86_64/MinSizeRel/_deps/re2-build/libre2.a \
-./onnxruntime/build/macOS_x86_64/MinSizeRel/_deps/google_nsync-build/libnsync_cpp.a \
-./onnxruntime/build/macOS_x86_64/MinSizeRel/_deps/protobuf-build/libprotobuf-lite.a \
-./onnxruntime/build/macOS_x86_64/MinSizeRel/_deps/abseil_cpp-build/absl/hash/libabsl_hash.a \
-./onnxruntime/build/macOS_x86_64/MinSizeRel/_deps/abseil_cpp-build/absl/hash/libabsl_city.a \
-./onnxruntime/build/macOS_x86_64/MinSizeRel/_deps/abseil_cpp-build/absl/hash/libabsl_low_level_hash.a \
-./onnxruntime/build/macOS_x86_64/MinSizeRel/_deps/abseil_cpp-build/absl/base/libabsl_throw_delegate.a \
-./onnxruntime/build/macOS_x86_64/MinSizeRel/_deps/abseil_cpp-build/absl/container/libabsl_raw_hash_set.a \
-./onnxruntime/build/macOS_x86_64/MinSizeRel/_deps/abseil_cpp-build/absl/base/libabsl_raw_logging_internal.a
+build_arch() {
+	onnx_config="$1"
+	arch="$2"
 
-libtool -static -o onnxruntime-macOS_arm64-static-combined.a \
-./onnxruntime/build/macOS_arm64/MinSizeRel/libonnx.a \
-./onnxruntime/build/macOS_arm64/MinSizeRel/libonnxruntime_graph.a \
-./onnxruntime/build/macOS_arm64/MinSizeRel/libonnx_proto.a \
-./onnxruntime/build/macOS_arm64/MinSizeRel/libonnxruntime_mlas.a \
-./onnxruntime/build/macOS_arm64/MinSizeRel/libonnx_test_data_proto.a \
-./onnxruntime/build/macOS_arm64/MinSizeRel/libonnxruntime_optimizer.a \
-./onnxruntime/build/macOS_arm64/MinSizeRel/libonnx_test_runner_common.a \
-./onnxruntime/build/macOS_arm64/MinSizeRel/libonnxruntime_providers.a \
-./onnxruntime/build/macOS_arm64/MinSizeRel/libonnxruntime_common.a \
-./onnxruntime/build/macOS_arm64/MinSizeRel/libonnxruntime_session.a \
-./onnxruntime/build/macOS_arm64/MinSizeRel/libonnxruntime_flatbuffers.a \
-./onnxruntime/build/macOS_arm64/MinSizeRel/libonnxruntime_test_utils.a \
-./onnxruntime/build/macOS_arm64/MinSizeRel/libonnxruntime_framework.a \
-./onnxruntime/build/macOS_arm64/MinSizeRel/libonnxruntime_util.a \
-./onnxruntime/build/macOS_arm64/MinSizeRel/_deps/re2-build/libre2.a \
-./onnxruntime/build/macOS_arm64/MinSizeRel/_deps/google_nsync-build/libnsync_cpp.a \
-./onnxruntime/build/macOS_arm64/MinSizeRel/_deps/protobuf-build/libprotobuf-lite.a \
-./onnxruntime/build/macOS_arm64/MinSizeRel/_deps/abseil_cpp-build/absl/hash/libabsl_hash.a \
-./onnxruntime/build/macOS_arm64/MinSizeRel/_deps/abseil_cpp-build/absl/hash/libabsl_city.a \
-./onnxruntime/build/macOS_arm64/MinSizeRel/_deps/abseil_cpp-build/absl/hash/libabsl_low_level_hash.a \
-./onnxruntime/build/macOS_arm64/MinSizeRel/_deps/abseil_cpp-build/absl/base/libabsl_throw_delegate.a \
-./onnxruntime/build/macOS_arm64/MinSizeRel/_deps/abseil_cpp-build/absl/container/libabsl_raw_hash_set.a \
-./onnxruntime/build/macOS_arm64/MinSizeRel/_deps/abseil_cpp-build/absl/base/libabsl_raw_logging_internal.a
+	CMAKE_BUILD_TYPE=MinSizeRel
 
-mkdir -p libs/macos-arm64_x86_64
-lipo -create onnxruntime-macOS_x86_64-static-combined.a onnxruntime-macOS_arm64-static-combined.a -output libs/macos-arm64_x86_64/onnxruntime.a
-rm onnxruntime-macOS_x86_64-static-combined.a
-rm onnxruntime-macOS_arm64-static-combined.a
+	python onnxruntime/tools/ci_build/build.py \
+	--build_dir "onnxruntime/build/macOS_${arch}" \
+	--config=${CMAKE_BUILD_TYPE} \
+	--parallel \
+	--minimal_build \
+	--apple_deploy_target="10.13" \
+	--disable_ml_ops --disable_exceptions --disable_rtti \
+	--include_ops_by_config "$onnx_config" \
+	--enable_reduced_operator_type_support \
+	--cmake_extra_defines CMAKE_OSX_ARCHITECTURES="${arch}" \
+	--skip_tests
+
+	libtool -static -o "onnxruntime-macOS_${arch}-static-combined.a" \
+	"./onnxruntime/build/macOS_${arch}/${CMAKE_BUILD_TYPE}/libonnx.a" \
+	"./onnxruntime/build/macOS_${arch}/${CMAKE_BUILD_TYPE}/libonnxruntime_graph.a" \
+	"./onnxruntime/build/macOS_${arch}/${CMAKE_BUILD_TYPE}/libonnx_proto.a" \
+	"./onnxruntime/build/macOS_${arch}/${CMAKE_BUILD_TYPE}/libonnxruntime_mlas.a" \
+	"./onnxruntime/build/macOS_${arch}/${CMAKE_BUILD_TYPE}/libonnx_test_data_proto.a" \
+	"./onnxruntime/build/macOS_${arch}/${CMAKE_BUILD_TYPE}/libonnxruntime_optimizer.a" \
+	"./onnxruntime/build/macOS_${arch}/${CMAKE_BUILD_TYPE}/libonnx_test_runner_common.a" \
+	"./onnxruntime/build/macOS_${arch}/${CMAKE_BUILD_TYPE}/libonnxruntime_common.a" \
+	"./onnxruntime/build/macOS_${arch}/${CMAKE_BUILD_TYPE}/libonnxruntime_providers.a" \
+	"./onnxruntime/build/macOS_${arch}/${CMAKE_BUILD_TYPE}/libonnxruntime_session.a" \
+	"./onnxruntime/build/macOS_${arch}/${CMAKE_BUILD_TYPE}/libonnxruntime_flatbuffers.a" \
+	"./onnxruntime/build/macOS_${arch}/${CMAKE_BUILD_TYPE}/libonnxruntime_test_utils.a" \
+	"./onnxruntime/build/macOS_${arch}/${CMAKE_BUILD_TYPE}/libonnxruntime_framework.a" \
+	"./onnxruntime/build/macOS_${arch}/${CMAKE_BUILD_TYPE}/libonnxruntime_util.a" \
+	"./onnxruntime/build/macOS_${arch}/${CMAKE_BUILD_TYPE}/_deps/re2-build/libre2.a" \
+	"./onnxruntime/build/macOS_${arch}/${CMAKE_BUILD_TYPE}/_deps/google_nsync-build/libnsync_cpp.a" \
+	"./onnxruntime/build/macOS_${arch}/${CMAKE_BUILD_TYPE}/_deps/protobuf-build/libprotobuf-lite.a" \
+	"./onnxruntime/build/macOS_${arch}/${CMAKE_BUILD_TYPE}/_deps/abseil_cpp-build/absl/hash/libabsl_hash.a" \
+	"./onnxruntime/build/macOS_${arch}/${CMAKE_BUILD_TYPE}/_deps/abseil_cpp-build/absl/hash/libabsl_city.a" \
+	"./onnxruntime/build/macOS_${arch}/${CMAKE_BUILD_TYPE}/_deps/abseil_cpp-build/absl/hash/libabsl_low_level_hash.a" \
+	"./onnxruntime/build/macOS_${arch}/${CMAKE_BUILD_TYPE}/_deps/abseil_cpp-build/absl/base/libabsl_throw_delegate.a" \
+	"./onnxruntime/build/macOS_${arch}/${CMAKE_BUILD_TYPE}/_deps/abseil_cpp-build/absl/container/libabsl_raw_hash_set.a" \
+	"./onnxruntime/build/macOS_${arch}/${CMAKE_BUILD_TYPE}/_deps/abseil_cpp-build/absl/base/libabsl_raw_logging_internal.a"
+}
+
+build_arch "$onnx_config" x86_64
+build_arch "$onnx_config" arm64
+
+dir="onnxruntime-${version}-macOS-universal"
+mkdir -p "$dir/lib"
+
+lipo -create onnxruntime-macos_x86_64-static-combined.a onnxruntime-macos_arm64-static-combined.a -output "$dir/lib/libonnxruntime.a"
+rm onnxruntime-macos_x86_64-static-combined.a
+rm onnxruntime-macos_arm64-static-combined.a

--- a/build-win.bat
+++ b/build-win.bat
@@ -1,74 +1,47 @@
-mkdir .\libs\win-x86_64\Release
-mkdir .\libs\win-x86_64\Debug
+setlocal
+@set "ONNX_CONFIG=%1"
+@if "%ONNX_CONFIG%"=="" (
+	@set "ONNX_CONFIG=model.required_operators_and_types.config"
+)
+set "CMAKE_BUILD_TYPE=MinSizeRel"
+mkdir ".\libs\win-x86_64\%CMAKE_BUILD_TYPE%"
 
 call onnxruntime\build.bat ^
---config=MinSizeRel ^
+--config="%CMAKE_BUILD_TYPE%" ^
 --cmake_generator="Visual Studio 16 2019" ^
 --parallel ^
 --minimal_build ^
 --disable_ml_ops --disable_exceptions --disable_rtti ^
---include_ops_by_config model.required_operators_and_types.config ^
+--include_ops_by_config "%ONNX_CONFIG%" ^
 --enable_reduced_operator_type_support ^
 --enable_msvc_static_runtime ^
---skip_tests
+--skip_tests ^
+	|| exit \b
 
-call "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvarsall.bat" x86_x64
-lib.exe /OUT:.\libs\win-x86_64\Release\onnxruntime.lib ^
-.\onnxruntime\build\Windows\MinSizeRel\MinSizeRel\onnx.lib ^
-.\onnxruntime\build\Windows\MinSizeRel\MinSizeRel\onnx_proto.lib ^
-.\onnxruntime\build\Windows\MinSizeRel\MinSizeRel\onnxruntime_graph.lib ^
-.\onnxruntime\build\Windows\MinSizeRel\MinSizeRel\onnxruntime_mlas.lib ^
-.\onnxruntime\build\Windows\MinSizeRel\MinSizeRel\onnxruntime_optimizer.lib ^
-.\onnxruntime\build\Windows\MinSizeRel\MinSizeRel\onnxruntime_providers.lib ^
-.\onnxruntime\build\Windows\MinSizeRel\MinSizeRel\onnxruntime_common.lib ^
-.\onnxruntime\build\Windows\MinSizeRel\MinSizeRel\onnxruntime_session.lib ^
-.\onnxruntime\build\Windows\MinSizeRel\MinSizeRel\onnxruntime_flatbuffers.lib ^
-.\onnxruntime\build\Windows\MinSizeRel\MinSizeRel\onnxruntime_test_utils.lib ^
-.\onnxruntime\build\Windows\MinSizeRel\MinSizeRel\onnxruntime_framework.lib ^
-.\onnxruntime\build\Windows\MinSizeRel\MinSizeRel\onnxruntime_util.lib ^
-.\onnxruntime\build\Windows\MinSizeRel\MinSizeRel\onnx_test_data_proto.lib ^
-.\onnxruntime\build\Windows\MinSizeRel\MinSizeRel\onnx_test_runner_common.lib ^
-.\onnxruntime\build\Windows\MinSizeRel\_deps\re2-build\MinSizeRel\re2.lib ^
-.\onnxruntime\build\Windows\MinSizeRel\_deps\protobuf-build\MinSizeRel\libprotobuf-lite.lib ^
-.\onnxruntime\build\Windows\MinSizeRel\_deps\abseil_cpp-build\absl\hash\MinSizeRel\absl_hash.lib ^
-.\onnxruntime\build\Windows\MinSizeRel\_deps\abseil_cpp-build\absl\hash\MinSizeRel\absl_city.lib ^
-.\onnxruntime\build\Windows\MinSizeRel\_deps\abseil_cpp-build\absl\hash\MinSizeRel\absl_low_level_hash.lib ^
-.\onnxruntime\build\Windows\MinSizeRel\_deps\abseil_cpp-build\absl\base\MinSizeRel\absl_throw_delegate.lib ^
-.\onnxruntime\build\Windows\MinSizeRel\_deps\abseil_cpp-build\absl\base\MinSizeRel\absl_raw_logging_internal.lib ^
-.\onnxruntime\build\Windows\MinSizeRel\_deps\abseil_cpp-build\absl\container\MinSizeRel\absl_raw_hash_set.lib ^
+call "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvarsall.bat" x86_x64 ^
+	|| exit \b
 
-call onnxruntime\build.bat ^
---config=Debug ^
---cmake_generator="Visual Studio 16 2019" ^
---parallel ^
---minimal_build ^
---disable_ml_ops --disable_exceptions --disable_rtti ^
---include_ops_by_config model.required_operators_and_types.config ^
---enable_reduced_operator_type_support ^
---enable_msvc_static_runtime ^
---skip_tests
+lib.exe /OUT:".\libs\win-x86_64\%CMAKE_BUILD_TYPE%\onnxruntime.lib" ^
+  ".\onnxruntime\build\Windows\%CMAKE_BUILD_TYPE%\%CMAKE_BUILD_TYPE%\onnx.lib" ^
+  ".\onnxruntime\build\Windows\%CMAKE_BUILD_TYPE%\%CMAKE_BUILD_TYPE%\onnx_proto.lib" ^
+  ".\onnxruntime\build\Windows\%CMAKE_BUILD_TYPE%\%CMAKE_BUILD_TYPE%\onnxruntime_graph.lib" ^
+  ".\onnxruntime\build\Windows\%CMAKE_BUILD_TYPE%\%CMAKE_BUILD_TYPE%\onnxruntime_mlas.lib" ^
+  ".\onnxruntime\build\Windows\%CMAKE_BUILD_TYPE%\%CMAKE_BUILD_TYPE%\onnxruntime_optimizer.lib" ^
+  ".\onnxruntime\build\Windows\%CMAKE_BUILD_TYPE%\%CMAKE_BUILD_TYPE%\onnxruntime_providers.lib" ^
+  ".\onnxruntime\build\Windows\%CMAKE_BUILD_TYPE%\%CMAKE_BUILD_TYPE%\onnxruntime_common.lib" ^
+  ".\onnxruntime\build\Windows\%CMAKE_BUILD_TYPE%\%CMAKE_BUILD_TYPE%\onnxruntime_session.lib" ^
+  ".\onnxruntime\build\Windows\%CMAKE_BUILD_TYPE%\%CMAKE_BUILD_TYPE%\onnxruntime_flatbuffers.lib" ^
+  ".\onnxruntime\build\Windows\%CMAKE_BUILD_TYPE%\%CMAKE_BUILD_TYPE%\onnxruntime_test_utils.lib" ^
+  ".\onnxruntime\build\Windows\%CMAKE_BUILD_TYPE%\%CMAKE_BUILD_TYPE%\onnxruntime_framework.lib" ^
+  ".\onnxruntime\build\Windows\%CMAKE_BUILD_TYPE%\%CMAKE_BUILD_TYPE%\onnxruntime_util.lib" ^
+  ".\onnxruntime\build\Windows\%CMAKE_BUILD_TYPE%\%CMAKE_BUILD_TYPE%\onnx_test_data_proto.lib" ^
+  ".\onnxruntime\build\Windows\%CMAKE_BUILD_TYPE%\%CMAKE_BUILD_TYPE%\onnx_test_runner_common.lib" ^
+  ".\onnxruntime\build\Windows\%CMAKE_BUILD_TYPE%\_deps\re2-build\%CMAKE_BUILD_TYPE%\re2.lib" ^
+  ".\onnxruntime\build\Windows\%CMAKE_BUILD_TYPE%\_deps\protobuf-build\%CMAKE_BUILD_TYPE%\libprotobuf-lite.lib" ^
+  ".\onnxruntime\build\Windows\%CMAKE_BUILD_TYPE%\_deps\abseil_cpp-build\absl\hash\%CMAKE_BUILD_TYPE%\absl_hash.lib" ^
+  ".\onnxruntime\build\Windows\%CMAKE_BUILD_TYPE%\_deps\abseil_cpp-build\absl\hash\%CMAKE_BUILD_TYPE%\absl_city.lib" ^
+  ".\onnxruntime\build\Windows\%CMAKE_BUILD_TYPE%\_deps\abseil_cpp-build\absl\hash\%CMAKE_BUILD_TYPE%\absl_low_level_hash.lib" ^
+  ".\onnxruntime\build\Windows\%CMAKE_BUILD_TYPE%\_deps\abseil_cpp-build\absl\base\%CMAKE_BUILD_TYPE%\absl_throw_delegate.lib" ^
+  ".\onnxruntime\build\Windows\%CMAKE_BUILD_TYPE%\_deps\abseil_cpp-build\absl\base\%CMAKE_BUILD_TYPE%\absl_raw_logging_internal.lib" ^
+  ".\onnxruntime\build\Windows\%CMAKE_BUILD_TYPE%\_deps\abseil_cpp-build\absl\container\%CMAKE_BUILD_TYPE%\absl_raw_hash_set.lib"
 
-call "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvarsall.bat" x86_x64
-lib.exe /OUT:.\libs\win-x86_64\Debug\onnxruntime.lib ^
-.\onnxruntime\build\Windows\Debug\Debug\onnx.lib ^
-.\onnxruntime\build\Windows\Debug\Debug\onnx_proto.lib ^
-.\onnxruntime\build\Windows\Debug\Debug\onnxruntime_graph.lib ^
-.\onnxruntime\build\Windows\Debug\Debug\onnxruntime_mlas.lib ^
-.\onnxruntime\build\Windows\Debug\Debug\onnxruntime_optimizer.lib ^
-.\onnxruntime\build\Windows\Debug\Debug\onnxruntime_providers.lib ^
-.\onnxruntime\build\Windows\Debug\Debug\onnxruntime_common.lib ^
-.\onnxruntime\build\Windows\Debug\Debug\onnxruntime_session.lib ^
-.\onnxruntime\build\Windows\Debug\Debug\onnxruntime_flatbuffers.lib ^
-.\onnxruntime\build\Windows\Debug\Debug\onnxruntime_test_utils.lib ^
-.\onnxruntime\build\Windows\Debug\Debug\onnxruntime_framework.lib ^
-.\onnxruntime\build\Windows\Debug\Debug\onnxruntime_util.lib ^
-.\onnxruntime\build\Windows\Debug\Debug\onnx_test_data_proto.lib ^
-.\onnxruntime\build\Windows\Debug\Debug\onnx_test_runner_common.lib ^
-.\onnxruntime\build\Windows\Debug\_deps\re2-build\Debug\re2.lib ^
-.\onnxruntime\build\Windows\Debug\_deps\protobuf-build\Debug\libprotobuf-lited.lib ^
-.\onnxruntime\build\Windows\Debug\_deps\abseil_cpp-build\absl\hash\Debug\absl_hash.lib ^
-.\onnxruntime\build\Windows\Debug\_deps\abseil_cpp-build\absl\hash\Debug\absl_city.lib ^
-.\onnxruntime\build\Windows\Debug\_deps\abseil_cpp-build\absl\hash\Debug\absl_low_level_hash.lib ^
-.\onnxruntime\build\Windows\Debug\_deps\abseil_cpp-build\absl\base\Debug\absl_throw_delegate.lib ^
-.\onnxruntime\build\Windows\Debug\_deps\abseil_cpp-build\absl\base\Debug\absl_raw_logging_internal.lib ^
-.\onnxruntime\build\Windows\Debug\_deps\abseil_cpp-build\absl\container\Debug\absl_raw_hash_set.lib ^

--- a/build-win.bat
+++ b/build-win.bat
@@ -6,9 +6,23 @@ setlocal
 set "CMAKE_BUILD_TYPE=MinSizeRel"
 mkdir ".\libs\win-x86_64\%CMAKE_BUILD_TYPE%"
 
+"%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" -latest -format value -property catalog_productLine > tmp || exit \b
+set /p version= < tmp
+set version=%version:Dev=%
+
+"%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" -latest -format value -property installationPath > tmp || exit \b
+set /p installationPath= < tmp
+
+"%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" -latest -format value -property catalog_productLineVersion > tmp || exit \b
+set /p year= < tmp
+
+del tmp
+
+
+
 call onnxruntime\build.bat ^
 --config="%CMAKE_BUILD_TYPE%" ^
---cmake_generator="Visual Studio 16 2019" ^
+--cmake_generator="Visual Studio %version% %year%" ^
 --parallel ^
 --minimal_build ^
 --disable_ml_ops --disable_exceptions --disable_rtti ^
@@ -18,7 +32,7 @@ call onnxruntime\build.bat ^
 --skip_tests ^
 	|| exit \b
 
-call "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvarsall.bat" x86_x64 ^
+call "%installationPath%\VC\Auxiliary\Build\vcvarsall.bat" x86_x64 ^
 	|| exit \b
 
 lib.exe /OUT:".\libs\win-x86_64\%CMAKE_BUILD_TYPE%\onnxruntime.lib" ^


### PR DESCRIPTION
Apart from refactoring here is a couple of changes I'm suggesting:
- build-win.bat only builds MinSizeRel but script has been parameterized for easy change
- build-mac.sh and build-win.bat accept an onnx config as their first argument if the user does not want the default.
- do not hard code Visual Studio version numbers, use the latest installed instead

Please let me know what you think, thanks!