### PR TITLE
add directory existence check before removal update onnxruntime

### DIFF
--- a/build-mac.sh
+++ b/build-mac.sh
@@ -17,7 +17,7 @@ build_arch() {
   --disable_ml_ops --disable_rtti \
   --include_ops_by_config "$ONNX_CONFIG" \
   --enable_reduced_operator_type_support \
-  --cmake_extra_defines CMAKE_OSX_ARCHITECTURES="${ARCH}" \
+  --cmake_extra_defines CMAKE_OSX_ARCHITECTURES="${ARCH}" CMAKE_POLICY_VERSION_MINIMUM=3.5 \
   --skip_tests
 
   BUILD_DIR=./onnxruntime/build/macOS_${ARCH}/${CMAKE_BUILD_TYPE}

--- a/convert-model-to-ort.sh
+++ b/convert-model-to-ort.sh
@@ -2,7 +2,10 @@
 
 #python -m tf2onnx.convert --saved-model model --output model.onnx --opset 13
 python -m onnxruntime.tools.convert_onnx_models_to_ort $1 --enable_type_reduction
-rm -R ./model/
+# check if directory exists before removing
+if [ -d "./model" ]; then
+    rm -R ./model/
+fi
 mkdir -p ./model
 # python verify_model.py
 python -m bin2c -o ./model/model.ort model.ort

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 #tensorflow==2.8
 #tf2onnx
-onnxruntime==1.16.3
+onnxruntime==1.19.2
 onnx==1.13.1
 bin2c


### PR DESCRIPTION
- Added a conditional check to verify if the "./model" directory exists before attempting to remove it. This prevents the "No such file or directory" when running the script for the first time or when the directory doesn't exist.
- Updated onnxruntime from 1.16.3 to 1.19.2 to resolve compatibility issues with NumPy 2.0.2. This eliminates the NumPy compatibility errors.
- The mac build was failing with errors from multiple deps due to outdated CMake minimum version requirements. This change adds CMAKE_POLICY_VERSION_MINIMUM=3.5 to the cmake_extra_defines, allowing the build to work with dependencies that specify older CMake versions without manually patching those dependencies. Fixes the error: "Compatibility with CMake < 3.5 has been removed from CMake."'